### PR TITLE
docs: Add seeds to README.md files

### DIFF
--- a/test/dijkstra/README.md
+++ b/test/dijkstra/README.md
@@ -42,3 +42,7 @@ Each `.in` file contains:
 File naming: `T{n}_sparse.in` and `T{n}_dense.in`
 
 These test cases evaluate how different containers (brodnik, std::vector, std::deque) perform as underlying storage for `std::priority_queue` in Dijkstra's algorithm.
+
+## Seeds
+
+* "Brodnik’s Data Structure in Practice, Revisited": 1195902166

--- a/test/heap/README.md
+++ b/test/heap/README.md
@@ -28,3 +28,7 @@ Each generated `.in` file contains:
 - Initial integers and operation sequences (`1 value` for push, `0` for pop)
 
 These test cases evaluate heap performance when different containers serve as underlying storage for priority queues.
+
+## Seeds
+
+* "Brodnik’s Data Structure in Practice, Revisited": 3204928272

--- a/test/sort/README.md
+++ b/test/sort/README.md
@@ -28,3 +28,7 @@ Each generated `.in` file contains:
 - Following lines: N integers for sorting
 
 These test cases evaluate random access performance and cache characteristics when different containers serve as underlying storage for sorting algorithms.
+
+## Seeds
+
+* "Brodnik’s Data Structure in Practice, Revisited": 1766789625

--- a/test/stack/README.md
+++ b/test/stack/README.md
@@ -61,3 +61,10 @@ make mode_all
 ```sh
 ./main --seed 12345
 ```
+
+## Seeds
+
+* "Brodnik’s Data Structure in Practice, Revisited":
+  * Mode 1: 2613726499
+  * Mode 2: 1969640844
+  * Mode 3: 2839142279


### PR DESCRIPTION
Adds the seeds used in the paper "Brodnik’s Data Structure in Practice, Revisited" to the README.md files of the corresponding tests.

The seeds added are:
- Dijkstra: 1195902166
- Sort: 1766789625
- Stack:
  - mode 1: 2613726499
  - mode 2: 1969640844
  - mode 3: 2839142279
- Heap: 3204928272